### PR TITLE
Adds RecordTypePicker which works for any type

### DIFF
--- a/.changeset/fluffy-needles-smile.md
+++ b/.changeset/fluffy-needles-smile.md
@@ -1,0 +1,26 @@
+---
+'@everipedia/iq-utils': patch
+---
+
+# Changes
+
+- Adds RecordTypePicker which works for any type
+
+# Example
+
+```ts
+// The NewWikiType will only have user, title, content, summary and user only has id, profile with username and avatar.
+type NewWikiType = RecordTypePicker<
+  Wiki,
+  {
+    user: {
+      id;
+      profile: {
+        username;
+        avatar;
+      };
+    };
+  },
+  'title' | 'content' | 'summary'
+>;
+```

--- a/src/types/wikiBuilder.ts
+++ b/src/types/wikiBuilder.ts
@@ -6,7 +6,7 @@ type DeepPartial<T> = {
 
 type PrimitiveType = number | string | boolean | symbol | null | undefined;
 
-type RecordTypeNonPrimitive<T> = DeepPartial<{
+export type RecordTypeNonPrimitive<T> = DeepPartial<{
   [K in keyof T]: [T[K]] extends [PrimitiveType] ? never : T[K];
 }>;
 

--- a/src/types/wikiBuilder.ts
+++ b/src/types/wikiBuilder.ts
@@ -1,33 +1,22 @@
-import {
-  Author,
-  BaseCategory,
-  BaseTag,
-  Image,
-  LanguagesISOEnum,
-  LinkedWikis,
-  MData,
-  Media,
-  User,
-  Wiki,
-} from './wiki';
+import { Wiki } from './wiki';
 
 type DeepPartial<T> = {
   [P in keyof T]?: DeepPartial<T[P]>;
 };
 
-export type WikiTypeBuilderExtender = DeepPartial<{
-  categories: BaseCategory[];
-  tags: BaseTag[];
-  images: Image[];
-  media: Media[];
-  user: User;
-  metadata: MData[];
-  linkedWikis?: LinkedWikis;
-  language: LanguagesISOEnum;
-  author: Author;
+type PrimitiveType = number | string | boolean | symbol | null | undefined;
+
+type RecordTypeNonPrimitive<T> = DeepPartial<{
+  [K in keyof T]: [T[K]] extends [PrimitiveType] ? never : T[K];
 }>;
 
-export type WikiTypeBuilder<
-  C extends WikiTypeBuilderExtender,
-  L extends keyof Wiki
-> = C & Pick<Wiki, Exclude<L, keyof C>>;
+export type RecordTypePicker<
+  T extends object,
+  NonPrimitiveOverrides extends RecordTypeNonPrimitive<T>,
+  Keys extends keyof T
+> = NonPrimitiveOverrides & Pick<T, Exclude<Keys, keyof NonPrimitiveOverrides>>;
+
+export type WikiBuilder<
+  NonPrimitiveOverrides extends RecordTypeNonPrimitive<Wiki>,
+  Keys extends keyof Wiki
+> = RecordTypePicker<Wiki, NonPrimitiveOverrides, Keys>;


### PR DESCRIPTION
# Changes
- Adds RecordTypePicker which works for any type

# Example 

```ts
// The NewWikiType will only have user, title, content, summary and user only has id, profile with username and avatar.
type NewWikiType = RecordTypePicker<
  Wiki,
  {
    user: {
      id;
      profile: {
        username;
        avatar;
      };
    };
  },
  'title' | 'content' | 'summary'
>;
```