### PR TITLE
Add chain explorers to wiki Links

### DIFF
--- a/.changeset/thirty-rivers-fold.md
+++ b/.changeset/thirty-rivers-fold.md
@@ -1,0 +1,5 @@
+---
+'@everipedia/iq-utils': minor
+---
+
+Adds basescan and ftmscan chain explorers

--- a/src/types/wiki.ts
+++ b/src/types/wiki.ts
@@ -82,6 +82,8 @@ export enum CommonMetaIds {
   POLYGONSCAN_PROFILE = 'polygonscan_profile',
   BSCSCAN_PROFILE = 'bscscan_profile',
   OPTIMISTIC_ETHERSCAN_PROFILE = 'optimistic_etherscan_profile',
+  BASESCAN_PROFILE = 'basescan_profile',
+  FTMSCAN_PROFILE = 'ftmscan_profile',
 }
 
 export const WikiPossibleSocialsList = [
@@ -111,6 +113,8 @@ export const WikiPossibleSocialsList = [
   CommonMetaIds.POLYGONSCAN_PROFILE,
   CommonMetaIds.BSCSCAN_PROFILE,
   CommonMetaIds.OPTIMISTIC_ETHERSCAN_PROFILE,
+  CommonMetaIds.BASESCAN_PROFILE,
+  CommonMetaIds.FTMSCAN_PROFILE,
 ];
 
 export enum ValidatorCodes {


### PR DESCRIPTION
-  Adds BaseScan and FTMscan explorers to wiki links

- BaseScan and FTMscan should be available to link in wiki Links


