### PR TITLE
resolving import issue

### DIFF
--- a/.changeset/import-error.md
+++ b/.changeset/import-error.md
@@ -1,0 +1,5 @@
+---
+'@everipedia/iq-utils': patch
+---
+
+Resolve issue with import error

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './lib/wikiScore';
+export * from './lib/isDeepEqual';
 export * from './types/wiki';
 export * from './types/wikiBuilder';


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  Users are unable to import the newly added function

- **What is the current behavior?** (You can also link to an open issue here)
   We can't import isDeepEqual
   
- **What is the new behavior (if this is a feature change)?**
   We can now import isDeepEqual
   
- **Other information**:
   None