### PR TITLE
Updating event metadata types

### DIFF
--- a/.changeset/update-base-event.md
+++ b/.changeset/update-base-event.md
@@ -1,0 +1,5 @@
+---
+'@everipedia/iq-utils': minor
+---
+
+Adds is base event id for the metadata structure

--- a/src/types/wiki.ts
+++ b/src/types/wiki.ts
@@ -228,6 +228,7 @@ export enum EventType {
 }
 
 export interface BaseEvents {
+  id?: string;
   date: string;
   title?: string;
   type: EventType;


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) 
   Update baseEvent types 

- **What is the current behavior?** (You can also link to an open issue here) 
    Currently we are unable to update the event metadata because of this missing id

- **What is the new behavior (if this is a feature change)?** 
  With the new id the update will reflect.

