### PR TITLE
🔨chore: adds default empty array for linkedWikis

### DIFF
--- a/.changeset/yellow-paws-press.md
+++ b/.changeset/yellow-paws-press.md
@@ -1,0 +1,5 @@
+---
+"@everipedia/iq-utils": minor
+---
+
+Adds .default([]) to linkedWikis keys

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -253,9 +253,18 @@ export const Wiki = z
 		version: z.number().default(1),
 		linkedWikis: z
 			.object({
-				[LinkedWikiKey.Enum.blockchains]: z.array(z.string()).nullish(),
-				[LinkedWikiKey.Enum.founders]: z.array(z.string()).nullish(),
-				[LinkedWikiKey.Enum.speakers]: z.array(z.string()).nullish(),
+				[LinkedWikiKey.Enum.blockchains]: z
+					.array(z.string())
+					.nullish()
+					.default([]),
+				[LinkedWikiKey.Enum.founders]: z
+					.array(z.string())
+					.nullish()
+					.default([]),
+				[LinkedWikiKey.Enum.speakers]: z
+					.array(z.string())
+					.nullish()
+					.default([]),
 			})
 			.nullish()
 			.default({}),


### PR DESCRIPTION
- **What kind of change does this PR introduce?** bug fix: This PR fixes error with parsing linked wikis

- **What is the current behavior?**fails to parse null linkedWikis

- **What is the new behavior (if this is a feature change)?** parse null linkedwikis

