### PR TITLE
Rename category enums from snake_case to kebab-case

### DIFF
--- a/.changeset/kebab-case-categories.md
+++ b/.changeset/kebab-case-categories.md
@@ -1,0 +1,5 @@
+---
+"@everipedia/iq-utils": major
+---
+
+Rename category enum values from snake_case to kebab-case

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -179,10 +179,10 @@ export type Tag = z.infer<typeof Tag>;
 
 export const Category = z.enum([
 	"people",
-	"projects_and_protocols",
+	"projects-and-protocols",
 	"organizations",
 	"cryptoassets",
-	"exchanges_and_marketplaces",
+	"exchanges-and-marketplaces",
 	"events",
 ]);
 export type Category = z.infer<typeof Category>;


### PR DESCRIPTION
## Summary
- Renames `projects_and_protocols` → `projects-and-protocols`
- Renames `exchanges_and_marketplaces` → `exchanges-and-marketplaces`
- Includes major changeset since this is a breaking change

## Test plan
- [x] Build passes
- [x] Tests pass