### PR TITLE
fix(schema): allow nullish EventType in BaseEvents

### DIFF
--- a/.changeset/allow-nullish-event-type.md
+++ b/.changeset/allow-nullish-event-type.md
@@ -1,0 +1,5 @@
+---
+"@everipedia/iq-utils": minor
+---
+
+Allow nullish EventType in BaseEvents schema to support existing wikis with null event types

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -243,7 +243,7 @@ export const BaseEvents = z.object({
 	id: z.string().nullish(),
 	date: z.string().nullable(),
 	title: z.string().nullish(),
-	type: EventType.nullable(),
+	type: EventType.nullish(),
 	description: z.string().nullish(),
 	link: z.string().nullish(),
 	multiDateStart: z.string().nullish(),


### PR DESCRIPTION
## Summary
- Changed `EventType` from `.nullable()` to `.nullish()` in `BaseEvents` schema
- Supports existing wikis where `eventType` is `null` or `undefined` in the database
- Prevents validation failures after upgrading from v0.4.x to v4.0.0

## Test plan
- [ ] Verify wiki edits/creation with null eventType no longer fail validation
- [ ] Verify valid EventType values (CREATED, DEFAULT, MULTIDATE) still work correctly

closes https://github.com/EveripediaNetwork/issues/issues/4826