### PR TITLE
add rootdata_profile to CommonMetaIds for RootData profile links

### DIFF
--- a/.changeset/add-rootdata-profile.md
+++ b/.changeset/add-rootdata-profile.md
@@ -1,0 +1,5 @@
+---
+"@everipedia/iq-utils": minor
+---
+
+Add `rootdata_profile` to CommonMetaIds for RootData (https://www.rootdata.com/) profile links

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -49,6 +49,7 @@ export const CommonMetaIds = z.enum([
 	"mirror_profile",
 	"tiktok_profile",
 	"explorer_injective_profile",
+	"rootdata_profile",
 ]);
 export type CommonMetaIds = z.infer<typeof CommonMetaIds>;
 


### PR DESCRIPTION
## Summary
Add `rootdata_profile` to `CommonMetaIds` for RootData (https://www.rootdata.com/) profile links, following the existing `*_profile` pattern. 

## Test plan
- `CommonMetaIds.enum.rootdata_profile` resolves and type-checks everywhere it used.

