### PR TITLE
ci(release): install with --frozen-lockfile to fix changesets 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
         uses: wyvox/action-setup-pnpm@v3
         with:
           node-version: '18'
+          args: --frozen-lockfile
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets


### PR DESCRIPTION
The release job ran a non-frozen pnpm install, drifting off the committed lockfile and resolving @changesets/cli up to 2.31.0, which pulls the now ESM-only human-id@4 via @changesets/write@0.4.0. On Node 18 the CJS require() of that ESM module throws ERR_REQUIRE_ESM, crashing 'changeset version' before the Version Packages PR could be created.

Pinning to the frozen lockfile keeps the proven CJS chain (@changesets/cli@2.27.8 -> @changesets/write@0.3.2 -> human-id@1.0.2) and makes the release install reproducible.