### PR TITLE
ci(release): run release job on Node 20 to fix changesets ERR_REQUIRE_ESM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,9 @@ jobs:
       - name: Setup Node.js and pnpm
         uses: wyvox/action-setup-pnpm@v3
         with:
-          node-version: '18'
-          
+          node-version: '20'
+          pnpm-version: 9
+          args: --frozen-lockfile
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1


### PR DESCRIPTION
## Summary
The Release workflow ran on Node 18, where `changeset version` crashed with `ERR_REQUIRE_ESM`: `@changesets/cli@2.31.0` requires the ESM-only `human-id@4` via a CommonJS `require()`, which Node 18 doesn't support. This blocked the auto-generated Version Packages PR (e.g. for the pending `rootdata_profile` changeset).

Bump the release job to Node 20 (≥20.19 supports `require(ESM)`), and pin `pnpm-version: 9` + `--frozen-lockfile` so CI reads the `9.0` lockfile and installs reproducibly.

## Test plan
- Verified locally on Node 22 (same `require(ESM)` support as Node 20.19+): loading `@changesets/cli` runs the `require('human-id')` path that crashed on Node 18 — exits 0 and detects the pending minor bump.
- After merge: Release workflow runs `changeset version` without `ERR_REQUIRE_ESM` and creates the Version Packages PR.